### PR TITLE
Code review

### DIFF
--- a/source/cpplocate/include/cpplocate/ModuleInfo.h
+++ b/source/cpplocate/include/cpplocate/ModuleInfo.h
@@ -4,6 +4,7 @@
 
 #include <string>
 #include <map>
+#include <iosfwd>
 
 #include <cpplocate/cpplocate_api.h>
 
@@ -36,13 +37,22 @@ public:
 
     /**
     *  @brief
+    *    Move constructor
+    *
+    *  @param[in] rh
+    *    Right-hand value to move
+    */
+    ModuleInfo(ModuleInfo && rh);
+
+    /**
+    *  @brief
     *    Destructor
     */
     ~ModuleInfo();
 
     /**
     *  @brief
-    *    Copy operator
+    *    Copy assignment operator
     *
     *  @param[in] rh
     *    Right-hand value to copy
@@ -51,6 +61,18 @@ public:
     *    Reference to this value
     */
     ModuleInfo & operator=(const ModuleInfo & rh);
+
+    /**
+    *  @brief
+    *    Move assignment operator
+    *
+    *  @param[in] rh
+    *    Right-hand value to move
+    *
+    *  @return
+    *    Reference to this value
+    */
+    ModuleInfo & operator=(ModuleInfo && rh);
 
     /**
     *  @brief
@@ -134,6 +156,15 @@ public:
 
 private:
     std::map<std::string, std::string> m_values; ///< Key/value map
+
+    /**
+    *  @brief
+    *    Print module info to stream
+    *
+    *  @param[in] stream
+    *    The stream to print to
+    */
+    void print(std::ostream & stream) const;
 };
 
 

--- a/source/cpplocate/include/cpplocate/cpplocate.h
+++ b/source/cpplocate/include/cpplocate/cpplocate.h
@@ -4,11 +4,14 @@
 
 #include <string>
 
-#include <cpplocate/ModuleInfo.h>
+#include <cpplocate/cpplocate_api.h>
 
 
 namespace cpplocate
 {
+
+
+class ModuleInfo;
 
 
 /**

--- a/source/cpplocate/source/cpplocate.cpp
+++ b/source/cpplocate/source/cpplocate.cpp
@@ -21,6 +21,7 @@
 #include <string>
 
 #include <cpplocate/utils.h>
+#include <cpplocate/ModuleInfo.h>
 
 
 namespace
@@ -127,7 +128,8 @@ ModuleInfo findModule(const std::string & name)
     std::vector<std::string> paths;
     std::string cppLocatePath = utils::getEnv("CPPLOCATE_PATH");
     utils::getPaths(cppLocatePath, paths);
-    for (std::string path : paths)
+
+    for (const std::string & path : paths)
     {
         if (utils::loadModule(path, name, info))
         {


### PR DESCRIPTION
Code review of library:
* Added move semantics for ModuleInfo (defining copy semantics prevents compilers from generating move semantics themselves)
* Extract method for module print code
* Use more forward declarations
* Use more guard clauses
* Don't search in map twice for each accessed value
* Introduce more const references