### PR TITLE
Static initialization hell in getExecutablePath on Windows

### DIFF
--- a/source/cpplocate/source/cpplocate.cpp
+++ b/source/cpplocate/source/cpplocate.cpp
@@ -5,7 +5,7 @@
     #include <unistd.h>
     #include <limits.h>
 #elif defined SYSTEM_WINDOWS
-    #include <stdlib.h>
+    #include <Windows.h>
 #elif defined SYSTEM_SOLARIS
     #include <stdlib.h>
     #include <limits.h>
@@ -56,10 +56,10 @@ std::string getExecutablePath()
 
 #elif defined SYSTEM_WINDOWS
 
-    char * exePath;
+    char exePath[MAX_PATH];
 
-    if (_get_pgmptr(&exePath) != 0) {
-        exePath = "";
+    if (GetModuleFileNameA(GetModuleHandleA(nullptr), exePath, sizeof(exePath)) == 0) {
+        exePath[0] = '\0';
     }
 
 #elif defined SYSTEM_SOLARIS


### PR DESCRIPTION
The old implementation relies on the value of a global variable (`_pgmptr`) and is thus prone to static initialization hell if used in a static initializer. Calling a system function (`GetModuleFileName`) should avoid this.

Currently, this bug causes any `gloperate`-based program to fail, due to the new `ScreenAlignedQuad`.

See http://stackoverflow.com/a/41113411