### PR TITLE
WIP: Find modinfo relative to its DLL

### DIFF
--- a/source/cpplocate/CMakeLists.txt
+++ b/source/cpplocate/CMakeLists.txt
@@ -31,6 +31,7 @@ set(source_path  "${CMAKE_CURRENT_SOURCE_DIR}/source")
 
 set(headers
     ${include_path}/cpplocate.h
+    ${include_path}/cpplocate.inl
     ${include_path}/utils.h
     ${include_path}/ModuleInfo.h
 )

--- a/source/cpplocate/include/cpplocate/cpplocate.h
+++ b/source/cpplocate/include/cpplocate/cpplocate.h
@@ -39,6 +39,8 @@ CPPLOCATE_API std::string getExecutablePath();
 */
 CPPLOCATE_API std::string getModulePath();
 
+static std::string getDllPath();
+
 /**
 *  @brief
 *    Tries to locate a module
@@ -53,16 +55,23 @@ CPPLOCATE_API std::string getModulePath();
 *    This functions looks for the filename "<name>.modinfo".
 *
 *    It searches the following locations:
-*    1. The current module path
-*    2. All pathes contained in the enironment variable CPPLOCATE_PATH
-*    2.a <path>/<name>.modinfo
-*    2.b <path>/<name>/<name>.modinfo
-*    3. Standard locations:
-*    3.a C:\Program Files\<name>\<name>.modinfo
-*    3.b /usr/share/<name>/<name>.modinfo
-*    3.c /usr/local/share/<name>/<name>.modinfo
+*    1. The current executable location
+*    2. The current library location
+*    3. All pathes contained in the enironment variable CPPLOCATE_PATH
+*    3.a <path>/<name>.modinfo
+*    3.b <path>/<name>/<name>.modinfo
+*    4. Standard locations:
+*    4.a C:\Program Files\<name>\<name>.modinfo
+*    4.b /usr/share/<name>/<name>.modinfo
+*    4.c /usr/local/share/<name>/<name>.modinfo
 */
-CPPLOCATE_API ModuleInfo findModule(const std::string & name);
+static ModuleInfo findModule(const std::string & name);
+
+
+CPPLOCATE_API ModuleInfo findModule(const std::string & name, const std::string & dllPath);
 
 
 } // namespace cpplocate
+
+
+#include <cpplocate/cpplocate.inl>

--- a/source/cpplocate/include/cpplocate/cpplocate.inl
+++ b/source/cpplocate/include/cpplocate/cpplocate.inl
@@ -1,0 +1,52 @@
+
+#pragma once
+
+
+#include <cpplocate/cpplocate.h>
+#include <cpplocate/ModuleInfo.h>
+
+#if defined SYSTEM_LINUX
+#include <unistd.h>
+#include <limits.h>
+#elif defined SYSTEM_WINDOWS
+#include <Windows.h>
+#elif defined SYSTEM_SOLARIS
+#include <stdlib.h>
+#include <limits.h>
+#elif defined SYSTEM_DARWIN
+#include <mach-o/dyld.h>
+#elif defined SYSTEM_FREEBSD
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#endif
+
+
+namespace cpplocate
+{
+
+
+static std::string getDllPath()
+{
+#if defined(SYSTEM_WINDOWS)
+    char path[MAX_PATH];
+    path[0] = '\0';
+
+    HMODULE module;
+    const auto success = GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, reinterpret_cast<LPCSTR>(getDllPath), &module);
+    if (success)
+    {
+        GetModuleFileNameA(module, path, sizeof path);
+    }
+#endif
+    
+    return path;
+}
+
+
+static ModuleInfo findModule(const std::string & name)
+{
+    return findModule(name, getDllPath());
+}
+
+
+} // namespace cpplocate

--- a/source/cpplocate/include/cpplocate/cpplocate.inl
+++ b/source/cpplocate/include/cpplocate/cpplocate.inl
@@ -6,8 +6,7 @@
 #include <cpplocate/ModuleInfo.h>
 
 #if defined SYSTEM_LINUX
-#include <unistd.h>
-#include <limits.h>
+#include <dlfcn.h>
 #elif defined SYSTEM_WINDOWS
 #include <Windows.h>
 #elif defined SYSTEM_SOLARIS
@@ -37,9 +36,15 @@ static std::string getDllPath()
     {
         GetModuleFileNameA(module, path, sizeof path);
     }
-#endif
-    
+
     return path;
+#else
+    Dl_info dlInfo;
+    dladdr(reinterpret_cast<void*>(getDllPath), &dlInfo);
+
+    return dlInfo.dli_fname;
+#endif
+
 }
 
 

--- a/source/cpplocate/include/cpplocate/cpplocate.inl
+++ b/source/cpplocate/include/cpplocate/cpplocate.inl
@@ -5,18 +5,10 @@
 #include <cpplocate/cpplocate.h>
 #include <cpplocate/ModuleInfo.h>
 
-#if defined SYSTEM_LINUX
-#include <dlfcn.h>
-#elif defined SYSTEM_WINDOWS
+#if defined SYSTEM_WINDOWS
 #include <Windows.h>
-#elif defined SYSTEM_SOLARIS
-#include <stdlib.h>
-#include <limits.h>
-#elif defined SYSTEM_DARWIN
-#include <mach-o/dyld.h>
-#elif defined SYSTEM_FREEBSD
-#include <sys/types.h>
-#include <sys/sysctl.h>
+#else
+#include <dlfcn.h>
 #endif
 
 

--- a/source/cpplocate/source/cpplocate.cpp
+++ b/source/cpplocate/source/cpplocate.cpp
@@ -114,12 +114,18 @@ std::string getModulePath()
     return utils::getDirectoryPath(getExecutablePath());
 }
 
-ModuleInfo findModule(const std::string & name)
+ModuleInfo findModule(const std::string & name, const std::string & dllPath)
 {
     ModuleInfo info;
 
-    // Search at current module location
+    // Search at current executable location
     if (utils::loadModule(getModulePath(), name, info))
+    {
+        return info;
+    }
+
+    // Search at current dll location
+    if (utils::loadModule(utils::getDirectoryPath(dllPath), name, info))
     {
         return info;
     }


### PR DESCRIPTION
This adds a `getDllPath` (to be renamed) function that retrieves the path to the current DLL/SO/DyLib. This path is then used to locate the corresponding modinfo file. The function is declared `static` and implemented in an `inl`-file to ensure that the coded is compiled into the using library, not cpplocate itself.

I tested the `getDllPath` function on Windows, Ubuntu and macOS.