### PR TITLE
Fix gcc warnings

### DIFF
--- a/cmake/CompileOptions.cmake
+++ b/cmake/CompileOptions.cmake
@@ -142,6 +142,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" OR "${CMAKE_CXX_COMPILER_ID}" MATCH
 
         $<$<VERSION_LESS:${CMAKE_VERSION},3.1>:
             -std=c++11
+            -std=c11
         >
     )
 endif ()

--- a/source/liblocate/source/utils.c
+++ b/source/liblocate/source/utils.c
@@ -107,7 +107,7 @@ void getDirectoryPart(const char * fullpath, unsigned int length, unsigned int *
         --iter;
     }
 
-    *newLength = (unsigned int)(iter > fullpath ? iter - fullpath : length);
+    *newLength = iter > fullpath ? (unsigned int)(iter - fullpath) : length;
 }
 
 void getBundlePart(const char * fullpath, unsigned int length, unsigned int * newLength)


### PR DESCRIPTION
  - Add --std=c11 to pre-cmake-3.1 options, produces some warnings itself ("-std=c++11 not valid for C" and vice versa)