### PR TITLE
Bump minimum CMake version to 3.5 to fix deprecation warning.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # 
 
 # CMake version
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
 #
 # Configure CMake environment

--- a/source/tests/CMakeLists.txt
+++ b/source/tests/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 
 # CMake version
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
 # Meta information about the project
 set(META_PROJECT_NAME "cpplocate")


### PR DESCRIPTION
Since [CMake 3.27](https://github.com/open-source-parsers/jsoncpp/issues/1521), a warning appears when using a `cmake_minimum_required` below 3.5:

```
CMake Deprecation Warning at deps/cpplocate-src/source/tests/CMakeLists.txt:7 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```

This PR simply bumps the minimum required CMake version from 3.0 to 3.5.
