### PR TITLE
[FIX] Use lowercase <windows.h> when cross-compiling via mingw

### DIFF
--- a/source/liblocate/source/liblocate.c
+++ b/source/liblocate/source/liblocate.c
@@ -13,7 +13,7 @@
     #define __USE_GNU
     #include <dlfcn.h>
 #elif defined(SYSTEM_WINDOWS)
-    #include <Windows.h>
+    #include <windows.h>
 #elif defined(SYSTEM_SOLARIS)
     #include <limits.h>
     #include <dlfcn.h>

--- a/source/liblocate/source/utils.c
+++ b/source/liblocate/source/utils.c
@@ -6,7 +6,7 @@
 
 #ifdef SYSTEM_WINDOWS
     #define WIN32_LEAN_AND_MEAN
-    #include <Windows.h>
+    #include <windows.h>
 #else
     #include <sys/stat.h>
 #endif


### PR DESCRIPTION
When cross-compiling this project from linux to windows via mingw, it fails with this error:

```
❯ cmake --build build-mingw                                         
[ 14%] Building C object source/cpplocate/CMakeFiles/cpplocate.dir/__/liblocate/source/liblocate.c.obj
/home/ammonium/src/cpplocate/source/liblocate/source/liblocate.c:16:14: fatal error: Windows.h: No such file or directory
   16 |     #include <Windows.h>
      |              ^~~~~~~~~~~
compilation terminated.
make[2]: *** [source/cpplocate/CMakeFiles/cpplocate.dir/build.make:95: source/cpplocate/CMakeFiles/cpplocate.dir/__/liblocate/source/liblocate.c.obj] Error 1
make[1]: *** [CMakeFiles/Makefile2:232: source/cpplocate/CMakeFiles/cpplocate.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```

This is because on linux, the path is case-sensitive and should be `#include <windows.h>`

The fix is simple, just change the include path to lowercase and it fixes it. This doesn't break windows since on windows they are case-insensitive anyways.

**Replication steps:**

Requirements:

- Be on linux, and have a mingw-w64 toolchain installed (e.g by installing the `mingw-w64` packages on Arch Linux)

1. Clone the project's main branch

Use  a custom toolchain file to try compiling this on windows via mingw and observe the error, such as this:
```
> cat mingw-w64-x86_64.cmake 
set(CMAKE_SYSTEM_NAME Windows)
set(CMAKE_SYSTEM_PROCESSOR x86_64)

set(CMAKE_C_COMPILER   x86_64-w64-mingw32-gcc)
set(CMAKE_CXX_COMPILER x86_64-w64-mingw32-g++)
set(CMAKE_RC_COMPILER  x86_64-w64-mingw32-windres)

set(CMAKE_FIND_ROOT_PATH /usr/x86_64-w64-mingw32)
set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

> cmake -B build-mingw -DCMAKE_TOOLCHAIN_FILE=mingw-w64-x86_64.cmake

> cmake --build build-mingw                                                    
[ 14%] Building CXX object source/cpplocate/CMakeFiles/cpplocate.dir/source/cpplocate.cpp.obj
[ 28%] Building C object source/cpplocate/CMakeFiles/cpplocate.dir/__/liblocate/source/liblocate.c.obj
/home/ammonium/src/cpplocate/source/liblocate/source/liblocate.c:16:14: fatal error: Windows.h: No such file or directory
   16 |     #include <Windows.h>
      |              ^~~~~~~~~~~
compilation terminated.
make[2]: *** [source/cpplocate/CMakeFiles/cpplocate.dir/build.make:95: source/cpplocate/CMakeFiles/cpplocate.dir/__/liblocate/source/liblocate.c.obj] Error 1
make[1]: *** [CMakeFiles/Makefile2:232: source/cpplocate/CMakeFiles/cpplocate.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```

Trying the same on this PR, the problem is fixed
